### PR TITLE
bug fixed: users list size set wrong

### DIFF
--- a/TLSharp.Core/Requests/GetUsersRequest.cs
+++ b/TLSharp.Core/Requests/GetUsersRequest.cs
@@ -27,11 +27,10 @@ namespace TLSharp.Core.Requests
 
         public override void OnResponse(BinaryReader reader)
         {
-            var code = reader.ReadUInt32();
-            var result = reader.ReadInt32(); // vector#1cb5c415
-            if (result != 0)
+            var code = reader.ReadUInt32(); // vector#1cb5c415
+            int users_len = reader.ReadInt32(); // vector length
+            if (users_len != 0)
             {
-                int users_len = reader.ReadInt32(); // vector length
                 users = new List<User>(users_len);
                 for (int i = 0; i < users_len; i++)
                     users.Add(TL.Parse<User>(reader));


### PR DESCRIPTION
var result was vector length, but again in next two lines, users_len used to set vector length, which was part of bytes related to parsing users.
according to https://core.telegram.org/method/users.getUsers :

first read => vector signature
second read => vector length
third+ read  => loop for parsing users