### PR TITLE
Add GetFile() method

### DIFF
--- a/TLSharp.Core/TelegramClient.cs
+++ b/TLSharp.Core/TelegramClient.cs
@@ -241,6 +241,24 @@ namespace TLSharp.Core
             return request.messages;
         }
 
+        public async Task<Tuple<storage_FileType, byte[]>> GetFile(long volume_id, int local_id, long secret, int offset, int limit)
+        {
+            var request = new GetFileRequest(new InputFileLocationConstructor(volume_id, local_id, secret), offset, limit);
+            await _sender.Send(request);
+            await _sender.Recieve(request);
+
+            return Tuple.Create(request.type, request.bytes);
+        }
+
+        public async Task<List<Dialog>> GetDialogs(int offset, int limit, int max_id = -1)
+        {
+            var request = new GetDialogsRequest(offset, max_id, limit);
+            await _sender.Send(request);
+            await _sender.Recieve(request);
+
+            return request.dialogs;
+        }
+
         private bool validateNumber(string number)
         {
             var regex = new Regex("^\\d{7,20}$");

--- a/TLSharp.Tests/TLSharpTests.cs
+++ b/TLSharp.Tests/TLSharpTests.cs
@@ -165,7 +165,6 @@ namespace TLSharp.Tests
             var res = await client.ImportContactByPhoneNumber(NumberToSendMessage);
 
             Assert.IsNotNull(res);
-            const string testFile = "TEST";
 
             var file = File.ReadAllBytes("../../data/cat.jpg");
 
@@ -176,6 +175,55 @@ namespace TLSharp.Tests
             var state = await client.SendMediaMessage(res.Value, mediaFile);
 
             Assert.IsTrue(state);
+        }
+
+        [TestMethod]
+        public async Task GetFile()
+        {
+            // Get uploaded file from last message (ie: cat.jpg)
+
+            var store = new FileSessionStore();
+            var client = new TelegramClient(store, "session", apiId, apiHash);
+            await client.Connect();
+            Assert.IsTrue(client.IsUserAuthorized());
+
+            var res = await client.ImportContactByPhoneNumber(NumberToSendMessage);
+            Assert.IsNotNull(res);
+
+            // Get last message
+            var hist = await client.GetMessagesHistoryForContact(res.Value, 0, 1);
+            Assert.AreEqual(1, hist.Count);
+
+            var message = (MessageConstructor) hist[0];
+            Assert.AreEqual(typeof(MessageMediaPhotoConstructor), message.media.GetType());
+
+            var media = (MessageMediaPhotoConstructor) message.media;
+            Assert.AreEqual(typeof(PhotoConstructor), media.photo.GetType());
+
+            var photo = (PhotoConstructor) media.photo;
+            Assert.AreEqual(3, photo.sizes.Count);
+            Assert.AreEqual(typeof(PhotoSizeConstructor), photo.sizes[2].GetType());
+
+            var photoSize = (PhotoSizeConstructor) photo.sizes[2];
+            Assert.AreEqual(typeof(FileLocationConstructor), photoSize.location.GetType());
+
+            var fileLocation = (FileLocationConstructor) photoSize.location;
+            var file = await client.GetFile(fileLocation.volume_id, fileLocation.local_id, fileLocation.secret, 0, photoSize.size + 1024);
+            storage_FileType type = file.Item1;
+            byte[] bytes = file.Item2;
+
+            string name = "../../data/get_file.";
+            if (type.GetType() == typeof(Storage_fileJpegConstructor))
+                name += "jpg";
+            else if (type.GetType() == typeof(Storage_fileGifConstructor))
+                name += "gif";
+            else if (type.GetType() == typeof(Storage_filePngConstructor))
+                name += "png";
+
+            using (var fileStream = new FileStream(name, FileMode.Create, FileAccess.Write))
+            {
+                fileStream.Write(bytes, 4, photoSize.size); // The first 4 bytes seem to be the error code
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
Hi,

I integrated the `GetFile()` method to the `TelegramClient` to retrieve files previously uploaded.

The unit test `GetFile()` assumes that the file `cat.jpg` was the last message posted and it downloads the image with the name `get_file.jpg`.

Could you please perform the pull request to integrate this change?

Thank you