### PR TITLE
Add contactName on ImportContact

### DIFF
--- a/TLSharp.Core/TelegramClient.cs
+++ b/TLSharp.Core/TelegramClient.cs
@@ -214,12 +214,15 @@ namespace TLSharp.Core
             return true;
         }
 
-        public async Task<int?> ImportContactByPhoneNumber(string phoneNumber)
+        public async Task<int?> ImportContactByPhoneNumber(string phoneNumber, string contactName = null)
         {
+            if (contactName == null)
+                contactName = "Default Name";
+
             if (!validateNumber(phoneNumber))
                 throw new InvalidOperationException("Invalid phone number. It should be only digit string, from 5 to 20 digits.");
 
-            var request = new ImportContactRequest(new InputPhoneContactConstructor(0, phoneNumber, "My Test Name", String.Empty));
+            var request = new ImportContactRequest(new InputPhoneContactConstructor(0, phoneNumber, contactName, String.Empty));
             await _sender.Send(request);
             await _sender.Receive(request);
 


### PR DESCRIPTION
When you import a contact by phone number, by default the name is "My Test Name". I added a optional new parameter (contactName), when it's null set as Default Name