### PR TITLE
build: switch to lower framework version (4.5.2 -> 4.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Library _almost_ ready for production usage. We need contributors to make 1.0.0 
 To use TLSharp follow next steps:
 
 1. Clone TLSharp from GitHub
-1. Compile source with VS2015
+1. Compile source with VS2015 or MonoDevelop
 1. Add reference to ```TLSharp.Core.dll``` to your awesome project.
 
 # Dependencies

--- a/TLSharp.Core/TLSharp.Core.csproj
+++ b/TLSharp.Core/TLSharp.Core.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TLSharp.Core</RootNamespace>
     <AssemblyName>TLSharp.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/TeleSharp.Generator/TeleSharp.Generator.csproj
+++ b/TeleSharp.Generator/TeleSharp.Generator.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TeleSharp.Generator</RootNamespace>
     <AssemblyName>TeleSharp.Generator</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/TeleSharp.TL/TeleSharp.TL.csproj
+++ b/TeleSharp.TL/TeleSharp.TL.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TeleSharp.TL</RootNamespace>
     <AssemblyName>TeleSharp.TL</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
This change is good because:
a) It's better to target a lower target framework version if
the project doesn't necessarily depend on the new features
of the newer versions (so, bigger target audience).
b) It lets compile the project with implementations of the
.NET Framework that are not compatible with 4.5.2. For example,
after this change I can successfully build TLSharp with the
Mono v4.2.1 that comes in my Ubuntu Linux 16.04.1.