### PR TITLE
Tests: put API settings also in app.config

### DIFF
--- a/TLSharp.Tests/TLSharpTests.cs
+++ b/TLSharp.Tests/TLSharpTests.cs
@@ -1,20 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
+﻿
 using System.Configuration;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using TeleSharp.TL;
-using TeleSharp.TL.Channels;
-using TeleSharp.TL.Contacts;
-using TeleSharp.TL.Messages;
 using TLSharp.Core;
-using TLSharp.Core.Auth;
-using TLSharp.Core.MTProto;
-using TLSharp.Core.Network;
 
 namespace TLSharp.Tests
 {

--- a/TLSharp.Tests/TLSharpTests.cs
+++ b/TLSharp.Tests/TLSharpTests.cs
@@ -27,14 +27,24 @@ namespace TLSharp.Tests
 
         private string NumberToAddToChat { get; set; }
 
-        private string apiHash = null;
+        private string ApiHash { get; set; }
 
-        private int apiId = 0;
+        private int ApiId { get; set; }
 
         [TestInitialize]
         public void Init()
         {
-            // Setup your phone numbers in app.config
+            // Setup your API settings and phone numbers in app.config
+
+            ApiHash = ConfigurationManager.AppSettings[nameof(ApiHash)];
+            if (string.IsNullOrEmpty(ApiHash))
+                Debug.WriteLine("ApiHash not configured in app.config! Some tests may fail.");
+
+            var apiId = ConfigurationManager.AppSettings[nameof(ApiId)];
+            if (string.IsNullOrEmpty(apiId))
+                Debug.WriteLine("ApiId not configured in app.config! Some tests may fail.");
+            ApiId = int.Parse(apiId);
+
             NumberToAuthenticate = ConfigurationManager.AppSettings[nameof(NumberToAuthenticate)];
             if (string.IsNullOrEmpty(NumberToAuthenticate))
                 Debug.WriteLine("NumberToAuthenticate not configured in app.config! Some tests may fail.");
@@ -63,7 +73,7 @@ namespace TLSharp.Tests
         [TestMethod]
         public async Task AuthUser()
         {
-            var client = new TelegramClient(apiId, apiHash);
+            var client = new TelegramClient(ApiId, ApiHash);
 
             await client.ConnectAsync();
 
@@ -79,7 +89,7 @@ namespace TLSharp.Tests
 		[TestMethod]
 	    public async Task SendMessageTest()
 	    {
-		    var client = new TelegramClient(apiId, apiHash);
+            var client = new TelegramClient(ApiId, ApiHash);
 
 			await client.ConnectAsync();
 
@@ -98,7 +108,7 @@ namespace TLSharp.Tests
 		[TestMethod]
 		public async Task SendMessageToChannelTest()
 		{
-			var client = new TelegramClient(apiId, apiHash);
+            var client = new TelegramClient(ApiId, ApiHash);
 
 			await client.ConnectAsync();
 
@@ -114,7 +124,7 @@ namespace TLSharp.Tests
 		[TestMethod]
         public async Task SignUpNewUser()
         {
-            var client = new TelegramClient(apiId, apiHash);
+            var client = new TelegramClient(ApiId, ApiHash);
             await client.ConnectAsync();
 
             var hash = await client.SendCodeRequestAsync(NotRegisteredNumberToSignUp);
@@ -131,7 +141,7 @@ namespace TLSharp.Tests
         [TestMethod]
         public async Task CheckPhones()
         {
-            var client = new TelegramClient(apiId, apiHash);
+            var client = new TelegramClient(ApiId, ApiHash);
             await client.ConnectAsync();
 
             var result = await client.IsPhoneRegisteredAsync(NumberToAuthenticate);

--- a/TLSharp.Tests/app.config
+++ b/TLSharp.Tests/app.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
+    <add key="ApiHash" value="" />
+    <add key="ApiId" value="" />
     <add key="NumberToAuthenticate" value="" />
     <add key="NotRegisteredNumberToSignUp" value=""/>
     <add key="NumberToSendMessage" value=""/>


### PR DESCRIPTION
For these tests to pass you not only needed to change
the app.config file but the .cs file as well with your
API settings (Hash & ID).

So let's put everything of them in the app.config so
it's easier to discover.