### PR TITLE
Tests: avoid NullReferenceException

### DIFF
--- a/TLSharp.Tests/TLSharpTests.cs
+++ b/TLSharp.Tests/TLSharpTests.cs
@@ -99,6 +99,12 @@ namespace TLSharp.Tests
                 .Where(x => x.GetType() == typeof(TLUser))
                 .Cast<TLUser>()
                 .FirstOrDefault(x => x.phone == NumberToSendMessage);
+
+            if (user == null)
+            {
+                throw new System.Exception("Number was not found in Contacts List of user: " + NumberToSendMessage);
+            }
+
             await client.SendTypingAsync(new TLInputPeerUser() { user_id = user.id });
             Thread.Sleep(3000);
             await client.SendMessageAsync(new TLInputPeerUser() { user_id = user.id }, "TEST");


### PR DESCRIPTION
Instead of throwing cryptic NullReferenceException
when this test fails, let's give more information
about what is going on, to the developer.