### PR TITLE
Always include an innerException when re-throwing 

### DIFF
--- a/TLSharp.Core/Network/MtProtoSender.cs
+++ b/TLSharp.Core/Network/MtProtoSender.cs
@@ -488,7 +488,7 @@ namespace TLSharp.Core.Network
         internal int DC { get; private set; }
 
         internal MigrationNeededException(int dc)
-            : base ("$Your phone number is registered to a different dc: {dc}. Please migrate.")
+            : base ($"Your phone number is registered to a different DC: {dc}. Please migrate.")
         {
             DC = dc;
         }

--- a/TLSharp.Tests/TLSharpTests.cs
+++ b/TLSharp.Tests/TLSharpTests.cs
@@ -49,9 +49,10 @@ namespace TLSharp.Tests
             {
                 return new TelegramClient(ApiId, ApiHash);
             }
-            catch (MissingApiConfigurationException)
+            catch (MissingApiConfigurationException ex)
             {
-                throw new Exception($"Please add your API settings to the `app.config` file. (More info: {MissingApiConfigurationException.InfoUrl})");
+                throw new Exception($"Please add your API settings to the `app.config` file. (More info: {MissingApiConfigurationException.InfoUrl})",
+                                    ex);
             }
         }
 

--- a/TeleSharp.TL/ObjectDeserializer.cs
+++ b/TeleSharp.TL/ObjectDeserializer.cs
@@ -21,7 +21,7 @@ namespace TeleSharp.TL
             }
             catch(Exception ex)
             {
-                throw new InvalidDataException("Constructor Invalid Or Context.Init Not Called !");
+                throw new InvalidDataException("Constructor Invalid Or Context.Init Not Called !", ex);
             }
             if (t.IsSubclassOf(typeof(TLMethod)))
             {


### PR DESCRIPTION
Hiding the previous thrown exception is a bad practice.