### PR TITLE
Friendlier exceptions for Auth testing

### DIFF
--- a/TLSharp.Core/Network/MtProtoSender.cs
+++ b/TLSharp.Core/Network/MtProtoSender.cs
@@ -293,6 +293,10 @@ namespace TLSharp.Core.Network
                     var dcIdx = int.Parse(resultString);
                     throw new UserMigrationException(dcIdx);
                 }
+                else if (errorMessage == "PHONE_CODE_INVALID")
+                {
+                    throw new InvalidPhoneCodeException("The numeric code used to authenticate does not match the numeric code sent by SMS/Telegram");
+                }
                 else
                 {
                     throw new InvalidOperationException(errorMessage);

--- a/TLSharp.Core/TelegramClient.cs
+++ b/TLSharp.Core/TelegramClient.cs
@@ -294,4 +294,9 @@ namespace TLSharp.Core
         {
         }
     }
+
+    public class InvalidPhoneCodeException : Exception
+    {
+        internal InvalidPhoneCodeException(string msg) : base(msg) { }
+    }
 }

--- a/TLSharp.Tests/app.config
+++ b/TLSharp.Tests/app.config
@@ -4,6 +4,7 @@
     <add key="ApiHash" value="" />
     <add key="ApiId" value="" />
     <add key="NumberToAuthenticate" value="" />
+    <add key="CodeToAuthenticate" value="" />
     <add key="NotRegisteredNumberToSignUp" value=""/>
     <add key="NumberToSendMessage" value=""/>
     <add key="UserNameToSendMessage" value=""/>


### PR DESCRIPTION
This change also lets you write the auth code in the
app.config file without the need to recompile/debug.
