### PR TITLE
Tests: add NUnit support

### DIFF
--- a/TLSharp.Tests.NUnit/TLSharp.Tests.NUnit.csproj
+++ b/TLSharp.Tests.NUnit/TLSharp.Tests.NUnit.csproj
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E90B705B-19FA-43BA-B952-69957976D12C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>TLSharp.Tests.NUnit</RootNamespace>
+    <AssemblyName>TLSharp.Tests.NUnit</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Test.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\TLSharp.Tests\app.config">
+      <Link>app.config</Link>
+    </None>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TLSharp.Tests\TLSharp.Tests.csproj">
+      <Project>{DE5C0467-EE99-4734-95F2-EFF7A0B99924}</Project>
+      <Name>TLSharp.Tests</Name>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/TLSharp.Tests.NUnit/Test.cs
+++ b/TLSharp.Tests.NUnit/Test.cs
@@ -1,0 +1,72 @@
+﻿
+using System;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+namespace TLSharp.Tests
+{
+    [TestFixture]
+    public class TLSharpTestsNUnit : TLSharpTests
+    {
+        [TestFixtureSetUp]
+        public void Init()
+        {
+            base.Init(o => Assert.IsNotNull(o), b => Assert.IsTrue(b));
+        }
+
+        [Test]
+        public async override Task AuthUser()
+        {
+            await base.AuthUser();
+        }
+
+        [Test]
+        public override async Task SendMessageTest()
+        {
+            await base.SendMessageTest();
+        }
+
+        [Test]
+        public override async Task SendMessageToChannelTest()
+        {
+            await base.SendMessageToChannelTest();
+        }
+
+        [Test]
+        public override async Task SendPhotoToContactTest()
+        {
+            await base.SendPhotoToContactTest();
+        }
+
+        [Test]
+        public override async Task SendBigFileToContactTest()
+        {
+            await base.SendBigFileToContactTest();
+        }
+
+        [Test]
+        public override async Task DownloadFileFromContactTest()
+        {
+            await base.DownloadFileFromContactTest();
+        }
+
+        [Test]
+        public override async Task DownloadFileFromWrongLocationTest()
+        {
+            await base.DownloadFileFromWrongLocationTest();
+        }
+
+        [Test]
+        public override async Task SignUpNewUser()
+        {
+            await base.SignUpNewUser();
+        }
+
+        [Test]
+        public override async Task CheckPhones()
+        {
+            await base.CheckPhones();
+        }
+    }
+}

--- a/TLSharp.Tests.NUnit/packages.config
+++ b/TLSharp.Tests.NUnit/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+</packages>

--- a/TLSharp.Tests.VS/Properties/AssemblyInfo.cs
+++ b/TLSharp.Tests.VS/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TLSharp.Tests.VS")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TLSharp.Tests.VS")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("affc3b00-3e4d-4327-8f7a-08ee41e0c8b7")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TLSharp.Tests.VS/TLSharp.Tests.VS.csproj
+++ b/TLSharp.Tests.VS/TLSharp.Tests.VS.csproj
@@ -1,0 +1,103 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{AFFC3B00-3E4D-4327-8F7A-08EE41E0C8B7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TLSharp.Tests.VS</RootNamespace>
+    <AssemblyName>TLSharp.Tests.VS</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="TLSharpTestsVs.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TeleSharp.TL\TeleSharp.TL.csproj">
+      <Project>{d6144517-91d2-4880-86df-e9ff5d7f383a}</Project>
+      <Name>TeleSharp.TL</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TLSharp.Core\TLSharp.Core.csproj">
+      <Project>{400d2544-1cc6-4d8a-a62c-2292d9947a16}</Project>
+      <Name>TLSharp.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TLSharp.Tests\TLSharp.Tests.csproj">
+      <Project>{de5c0467-ee99-4734-95f2-eff7a0b99924}</Project>
+      <Name>TLSharp.Tests</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\TLSharp.Tests\app.config">
+      <Link>app.config</Link>
+    </None>
+  </ItemGroup>
+  <ItemGroup />
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/TLSharp.Tests.VS/TLSharpTestsVs.cs
+++ b/TLSharp.Tests.VS/TLSharpTestsVs.cs
@@ -1,0 +1,71 @@
+﻿
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TLSharp.Tests
+{
+    [TestClass]
+    public class TLSharpTestsVS : TLSharpTests
+    {
+        [TestInitialize]
+        public void Init()
+        {
+            base.Init(o => Assert.IsNotNull(o), b => Assert.IsTrue(b));
+        }
+        
+        [TestMethod]
+        public override async Task AuthUser()
+        {
+            await base.AuthUser();
+        }
+
+        [TestMethod]
+        public override async Task SendMessageTest()
+        {
+            await base.SendMessageTest();
+        }
+
+        [TestMethod]
+        public override async Task SendMessageToChannelTest()
+        {
+            await base.SendMessageToChannelTest();
+        }
+
+        [TestMethod]
+        public override async Task SendPhotoToContactTest()
+        {
+            await base.SendPhotoToContactTest();
+        }
+
+        [TestMethod]
+        public override async Task SendBigFileToContactTest()
+        {
+            await base.SendBigFileToContactTest();
+        }
+
+        [TestMethod]
+        public override async Task DownloadFileFromContactTest()
+        {
+            await base.DownloadFileFromContactTest();
+        }
+
+        [TestMethod]
+        public override async Task DownloadFileFromWrongLocationTest()
+        {
+            await base.DownloadFileFromWrongLocationTest();
+        }
+
+        [TestMethod]
+        public override async Task SignUpNewUser()
+        {
+            await base.SignUpNewUser();
+        }
+
+        [TestMethod]
+        public override async Task CheckPhones()
+        {
+            await base.CheckPhones();
+        }
+    }
+}

--- a/TLSharp.Tests/TLSharp.Tests.csproj
+++ b/TLSharp.Tests/TLSharp.Tests.csproj
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -8,14 +9,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TLSharp.Tests</RootNamespace>
     <AssemblyName>TLSharp.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
-    <IsCodedUITest>False</IsCodedUITest>
-    <TestProjectType>UnitTest</TestProjectType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -38,18 +33,6 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
   </ItemGroup>
-  <Choose>
-    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
   <ItemGroup>
     <Compile Include="TLSharpTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -73,25 +56,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/TLSharp.Tests/TLSharpTests.cs
+++ b/TLSharp.Tests/TLSharpTests.cs
@@ -7,8 +7,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
 using TeleSharp.TL;
 using TeleSharp.TL.Messages;
 using TLSharp.Core;
@@ -17,7 +15,6 @@ using TLSharp.Core.Utils;
 
 namespace TLSharp.Tests
 {
-    [TestClass]
     public class TLSharpTests
     {
         private string NumberToSendMessage { get; set; }
@@ -38,9 +35,27 @@ namespace TLSharp.Tests
 
         private int ApiId { get; set; }
 
-        [TestInitialize]
-        public void Init()
+        class Assert
         {
+            static internal void IsNotNull(object obj)
+            {
+                IsNotNullHanlder(obj);
+            }
+
+            static internal void IsTrue(bool cond)
+            {
+                IsTrueHandler(cond);
+            }
+        }
+
+        internal static Action<object> IsNotNullHanlder;
+        internal static Action<bool> IsTrueHandler;
+
+        protected void Init(Action<object> notNullHandler, Action<bool> trueHandler)
+        {
+            IsNotNullHanlder = notNullHandler;
+            IsTrueHandler = trueHandler;
+
             // Setup your API settings and phone numbers in app.config
             GatherTestConfiguration();
         }
@@ -97,8 +112,7 @@ namespace TLSharp.Tests
                 Debug.WriteLine(appConfigMsgWarning, nameof(NumberToAddToChat));
         }
 
-        [TestMethod]
-        public async Task AuthUser()
+        public virtual async Task AuthUser()
         {
             var client = NewClient();
 
@@ -127,8 +141,7 @@ namespace TLSharp.Tests
             Assert.IsTrue(client.IsUserAuthorized());
         }
 
-        [TestMethod]
-        public async Task SendMessageTest()
+        public virtual async Task SendMessageTest()
         {
             NumberToSendMessage = ConfigurationManager.AppSettings[nameof(NumberToSendMessage)];
             if (string.IsNullOrWhiteSpace(NumberToSendMessage))
@@ -160,8 +173,7 @@ namespace TLSharp.Tests
             await client.SendMessageAsync(new TLInputPeerUser() { user_id = user.id }, "TEST");
         }
 
-        [TestMethod]
-        public async Task SendMessageToChannelTest()
+        public virtual async Task SendMessageToChannelTest()
         {
             var client = NewClient();
 
@@ -176,8 +188,7 @@ namespace TLSharp.Tests
             await client.SendMessageAsync(new TLInputPeerChannel() { channel_id = chat.id, access_hash = chat.access_hash.Value }, "TEST MSG");
         }
 
-        [TestMethod]
-        public async Task SendPhotoToContactTest()
+        public virtual async Task SendPhotoToContactTest()
         {
             var client = NewClient();
 
@@ -194,8 +205,7 @@ namespace TLSharp.Tests
             await client.SendUploadedPhoto(new TLInputPeerUser() { user_id = user.id }, fileResult, "kitty");
         }
 
-        [TestMethod]
-        public async Task SendBigFileToContactTest()
+        public virtual async Task SendBigFileToContactTest()
         {
             var client = NewClient();
 
@@ -218,8 +228,7 @@ namespace TLSharp.Tests
                 new TLVector<TLAbsDocumentAttribute>());
         }
 
-        [TestMethod]
-        public async Task DownloadFileFromContactTest()
+        public virtual async Task DownloadFileFromContactTest()
         {
             var client = NewClient();
 
@@ -257,9 +266,7 @@ namespace TLSharp.Tests
             Assert.IsTrue(resFile.bytes.Length > 0);
         }
 
-
-        [TestMethod]
-        public async Task DownloadFileFromWrongLocationTest()
+        public virtual async Task DownloadFileFromWrongLocationTest()
         {
             var client = NewClient();
 
@@ -287,8 +294,7 @@ namespace TLSharp.Tests
             Assert.IsTrue(resFile.bytes.Length > 0);
         }
 
-        [TestMethod]
-        public async Task SignUpNewUser()
+        public virtual async Task SignUpNewUser()
         {
             var client = NewClient();
             await client.ConnectAsync();
@@ -304,8 +310,7 @@ namespace TLSharp.Tests
             Assert.IsNotNull(loggedInUser);
         }
 
-        [TestMethod]
-        public async Task CheckPhones()
+        public virtual async Task CheckPhones()
         {
             var client = NewClient();
             await client.ConnectAsync();

--- a/TLSharp.sln
+++ b/TLSharp.sln
@@ -11,6 +11,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TeleSharp.Generator", "Tele
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TLSharp.Tests", "TLSharp.Tests\TLSharp.Tests.csproj", "{DE5C0467-EE99-4734-95F2-EFF7A0B99924}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TLSharp.Tests.VS", "TLSharp.Tests.VS\TLSharp.Tests.VS.csproj", "{AFFC3B00-3E4D-4327-8F7A-08EE41E0C8B7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TLSharp.Tests.NUnit", "TLSharp.Tests.NUnit\TLSharp.Tests.NUnit.csproj", "{E90B705B-19FA-43BA-B952-69957976D12C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +37,14 @@ Global
 		{DE5C0467-EE99-4734-95F2-EFF7A0B99924}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DE5C0467-EE99-4734-95F2-EFF7A0B99924}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DE5C0467-EE99-4734-95F2-EFF7A0B99924}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AFFC3B00-3E4D-4327-8F7A-08EE41E0C8B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AFFC3B00-3E4D-4327-8F7A-08EE41E0C8B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AFFC3B00-3E4D-4327-8F7A-08EE41E0C8B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AFFC3B00-3E4D-4327-8F7A-08EE41E0C8B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E90B705B-19FA-43BA-B952-69957976D12C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E90B705B-19FA-43BA-B952-69957976D12C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E90B705B-19FA-43BA-B952-69957976D12C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E90B705B-19FA-43BA-B952-69957976D12C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
What's an open source project that cannot be
tested in an open source platform? The best
open source .NET IDE that works in Linux
(MonoDevelop) doesn't have support for
VisualStudio Testing framework, but it has
support for NUnit.

By abstracting a bit the TLSharp.Tests assembly
we can have two different wrappers, one for
NUnit tests and other for VisualStudio tests,
so no one can be left behind.