### PR TITLE
Added possibility to do ping request (SendPingAsync method)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ For your convenience TLSharp have wrappers for several Telegram API methods. You
 1. SendUploadedDocument
 1. GetFile
 1. UploadFile
+1. SendPingAsync
 
 **What if you can't find needed method at the list?**
 

--- a/TLSharp.Core/Requests/PingRequest.cs
+++ b/TLSharp.Core/Requests/PingRequest.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using TeleSharp.TL;
+using TLSharp.Core.Utils;
+
+namespace TLSharp.Core.Requests
+{
+    public class PingRequest : TeleSharp.TL.TLMethod
+    {
+        public PingRequest()
+        {
+        }
+
+        public override void SerializeBody(BinaryWriter writer)
+        {
+            writer.Write(Constructor);
+            writer.Write(Helpers.GenerateRandomLong());
+        }
+
+        public override void DeserializeBody(BinaryReader reader)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void deserializeResponse(BinaryReader stream)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int Constructor
+        {
+            get
+            {
+                return 0x7abe77ec;
+            }
+        }
+    }
+}

--- a/TLSharp.Core/TLSharp.Core.csproj
+++ b/TLSharp.Core/TLSharp.Core.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Network\TcpTransport.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Requests\AckRequest.cs" />
+    <Compile Include="Requests\PingRequest.cs" />
     <Compile Include="Utils\UploadHelper.cs" />
     <Compile Include="Session.cs" />
     <Compile Include="TelegramClient.cs" />

--- a/TLSharp.Core/TelegramClient.cs
+++ b/TLSharp.Core/TelegramClient.cs
@@ -174,7 +174,7 @@ namespace TLSharp.Core
         {
             await _sender.Send(methodToExecute);
             await _sender.Receive(methodToExecute);
-            
+
             var result = methodToExecute.GetType().GetProperty("Response").GetValue(methodToExecute);
 
             return (T)result;
@@ -290,6 +290,11 @@ namespace TLSharp.Core
             }
 
             return result;
+        }
+
+        public async Task SendPingAsync()
+        {
+            await _sender.SendPingAsync();
         }
 
         private void OnUserAuthenticated(TLUser TLUser)


### PR DESCRIPTION
Hi there,

according to [this](https://github.com/telegramdesktop/tdesktop/blob/master/Telegram/SourceFiles/mtproto/scheme.tl#L109) TL scheme has ping-pong request.

Usage:
```
await client.SendPingAsync();
````

It will send ping request and wait for pong response.