### PR TITLE
FloodExceptionShouldNotCauseCannotReadPackageLengthError

### DIFF
--- a/TLSharp.Tests.NUnit/Test.cs
+++ b/TLSharp.Tests.NUnit/Test.cs
@@ -68,5 +68,12 @@ namespace TLSharp.Tests
         {
             await base.CheckPhones();
         }
+
+        [Test]
+        [Ignore("FIXME")]
+        public override async Task FloodExceptionShouldNotCauseCannotReadPackageLengthError()
+        {
+            await base.FloodExceptionShouldNotCauseCannotReadPackageLengthError();
+        }
     }
 }

--- a/TLSharp.Tests.VS/TLSharpTestsVs.cs
+++ b/TLSharp.Tests.VS/TLSharpTestsVs.cs
@@ -67,5 +67,11 @@ namespace TLSharp.Tests
         {
             await base.CheckPhones();
         }
+        [TestMethod]
+        [Ignore]
+        public override async Task FloodExceptionShouldNotCauseCannotReadPackageLengthError()
+        {
+            await base.FloodExceptionShouldNotCauseCannotReadPackageLengthError();
+        }
     }
 }

--- a/TLSharp.Tests/TLSharpTests.cs
+++ b/TLSharp.Tests/TLSharpTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using TeleSharp.TL;
 using TeleSharp.TL.Messages;
 using TLSharp.Core;
+using TLSharp.Core.Network;
 using TLSharp.Core.Requests;
 using TLSharp.Core.Utils;
 
@@ -329,6 +330,21 @@ namespace TLSharp.Tests
 
             var result = await client.IsPhoneRegisteredAsync(NumberToAuthenticate);
             Assert.IsTrue(result);
+        }
+        public virtual async Task FloodExceptionShouldNotCauseCannotReadPackageLengthError()
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                try
+                {
+                    await CheckPhones();
+                }
+                catch (FloodException floodException)
+                {
+                    Console.WriteLine($"FLOODEXCEPTION: {floodException}");
+                    Thread.Sleep(floodException.TimeToWait);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Tests: include testcase for "couldn't read packet length" bug
It seems that after triggering a FloodException, and waiting the required time
to be able to use Telegram again, TLSharp throws an exception. I include the
way to reproduce this bug as an [Ignore]d test with the hope that someone
may help me fix the problem soon.

For reference, the whole stacktrace of the exception was:

Test Name:	FloodExceptionShouldNotCauseCannotReadPackageLengthError
Test FullName:	TLSharp.Tests.TLSharpTestsVS.FloodExceptionShouldNotCauseCannotReadPackageLengthError
Test Source:	D:\Projects\GitHub\TLSharp\TLSharp.Tests.VS\TLSharpTestsVs.cs : line 72
Test Outcome:	Failed
Test Duration:	0:04:30.7467012

Result StackTrace:
at TLSharp.Core.Network.TcpTransport.<Receieve>d__4.MoveNext() in D:\Projects\GitHub\TLSharp\TLSharp.Core\Network\TcpTransport.cs:line 39
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at TLSharp.Core.Network.MtProtoSender.<Receive>d__9.MoveNext() in D:\Projects\GitHub\TLSharp\TLSharp.Core\Network\MtProtoSender.cs:line 139
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at TLSharp.Core.TelegramClient.<ConnectAsync>d__8.MoveNext() in D:\Projects\GitHub\TLSharp\TLSharp.Core\TelegramClient.cs:line 76
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at TLSharp.Tests.TLSharpTests.<CheckPhones>d__54.MoveNext() in D:\Projects\GitHub\TLSharp\TLSharp.Tests\TLSharpTests.cs:line 329
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at TLSharp.Tests.TLSharpTestsVS.<CheckPhones>d__9.MoveNext() in D:\Projects\GitHub\TLSharp\TLSharp.Tests.VS\TLSharpTestsVs.cs:line 68
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at TLSharp.Tests.TLSharpTests.<FloodExceptionShouldNotCauseCannotReadPackageLengthError>d__55.MoveNext() in D:\Projects\GitHub\TLSharp\TLSharp.Tests\TLSharpTests.cs:line 340
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at TLSharp.Tests.TLSharpTestsVS.<FloodExceptionShouldNotCauseCannotReadPackageLengthError>d__10.MoveNext() in D:\Projects\GitHub\TLSharp\TLSharp.Tests.VS\TLSharpTestsVs.cs:line 73
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
Result Message:
Test method TLSharp.Tests.TLSharpTestsVS.FloodExceptionShouldNotCauseCannotReadPackageLengthError threw exception:
System.InvalidOperationException: Couldn't read the packet length