### PR TITLE
Connect through http proxy authentication

### DIFF
--- a/TLSharp.Core/Network/TcpTransport.cs
+++ b/TLSharp.Core/Network/TcpTransport.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;

--- a/TLSharp.Core/Network/TcpTransport.cs
+++ b/TLSharp.Core/Network/TcpTransport.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;

--- a/TLSharp.Core/Network/TcpTransport.cs
+++ b/TLSharp.Core/Network/TcpTransport.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace TLSharp.Core.Network
@@ -10,6 +11,65 @@ namespace TLSharp.Core.Network
     {
         private readonly TcpClient _tcpClient;
         private int sendCounter = 0;
+
+
+        static TcpClient connectViaHTTPProxy(
+            string targetHost,
+            int targetPort,
+            string httpProxyHost,
+            int httpProxyPort,
+            string proxyUserName,
+            string proxyPassword)
+        {
+            var uriBuilder = new UriBuilder
+            {
+                Scheme = Uri.UriSchemeHttp,
+                Host = httpProxyHost,
+                Port = httpProxyPort
+            };
+
+            var proxyUri = uriBuilder.Uri;
+
+            var request = WebRequest.Create(
+                "http://" + targetHost + ":" + targetPort);
+
+            var webProxy = new WebProxy(proxyUri);
+
+            request.Proxy = webProxy;
+            request.Method = "CONNECT";
+
+            var credentials = new NetworkCredential(
+                proxyUserName, proxyPassword);
+
+            webProxy.Credentials = credentials;
+
+            var response = request.GetResponse();
+
+            var responseStream = response.GetResponseStream();
+            Debug.Assert(responseStream != null);
+
+            const BindingFlags Flags = BindingFlags.NonPublic | BindingFlags.Instance;
+
+            var rsType = responseStream.GetType();
+            var connectionProperty = rsType.GetProperty("Connection", Flags);
+
+            var connection = connectionProperty.GetValue(responseStream, null);
+            var connectionType = connection.GetType();
+            var networkStreamProperty = connectionType.GetProperty("NetworkStream", Flags);
+
+            var networkStream = networkStreamProperty.GetValue(connection, null);
+            var nsType = networkStream.GetType();
+            var socketProperty = nsType.GetProperty("Socket", Flags);
+            var socket = (Socket)socketProperty.GetValue(networkStream, null);
+
+            return new TcpClient { Client = socket };
+        }
+
+        public TcpTransport(string address, int port, string httpProxyHost,
+            int httpProxyPort, string proxyUserName, string proxyPassword)
+        {
+            _tcpClient = connectViaHTTPProxy(address, port, httpProxyHost, httpProxyPort, proxyUserName, proxyPassword);
+        }
 
         public TcpTransport(string address, int port)
         {

--- a/TLSharp.Core/TelegramClient.cs
+++ b/TLSharp.Core/TelegramClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;

--- a/TLSharp.Core/TelegramClient.cs
+++ b/TLSharp.Core/TelegramClient.cs
@@ -30,6 +30,12 @@ namespace TLSharp.Core
         private int _apiId = 0;
         private Session _session;
         private List<TLDcOption> dcOptions;
+        private bool _usingProxy = false;
+        private string _httpProxyHost;
+        private int _httpProxyPort;
+        private string _proxyUserName;
+        private string _proxyPassword;
+
 
         public TelegramClient(int apiId, string apiHash, ISessionStore store = null, string sessionUserId = "session")
         {
@@ -49,6 +55,7 @@ namespace TLSharp.Core
             _transport = new TcpTransport(_session.ServerAddress, _session.Port);
         }
 
+
         public TelegramClient(int apiId, string apiHash, string httpProxyHost, int httpProxyPort, string proxyUserName, string proxyPassword,
             ISessionStore store = null, string sessionUserId = "session")
         {
@@ -67,7 +74,13 @@ namespace TLSharp.Core
             _transport = new TcpTransport(_session.ServerAddress, _session.Port,
                 httpProxyHost, httpProxyPort, proxyUserName, proxyPassword);
 
-        }
+            _usingProxy = true;
+            _httpProxyHost = httpProxyHost;
+            _httpProxyPort = httpProxyPort;
+            _proxyUserName = proxyUserName;
+            _proxyPassword = proxyPassword;
+
+    }
 
         public async Task<bool> ConnectAsync(bool reconnect = false)
         {
@@ -107,7 +120,16 @@ namespace TLSharp.Core
 
             var dc = dcOptions.First(d => d.id == dcId);
 
-            _transport = new TcpTransport(dc.ip_address, dc.port);
+            if (!_usingProxy)
+            {
+                _transport = new TcpTransport(dc.ip_address, dc.port);
+            }
+            else
+            {
+                _transport = new TcpTransport(dc.ip_address, dc.port,
+                                             _httpProxyHost, _httpProxyPort, _proxyUserName, _proxyPassword);
+            }
+
             _session.ServerAddress = dc.ip_address;
             _session.Port = dc.port;
 

--- a/TLSharp.Core/TelegramClient.cs
+++ b/TLSharp.Core/TelegramClient.cs
@@ -49,6 +49,26 @@ namespace TLSharp.Core
             _transport = new TcpTransport(_session.ServerAddress, _session.Port);
         }
 
+        public TelegramClient(int apiId, string apiHash, string httpProxyHost, int httpProxyPort, string proxyUserName, string proxyPassword,
+            ISessionStore store = null, string sessionUserId = "session")
+        {
+            if (store == null)
+                store = new FileSessionStore();
+
+            TLContext.Init();
+            _apiHash = apiHash;
+            _apiId = apiId;
+            if (_apiId == default(int))
+                throw new MissingApiConfigurationException("API_ID");
+            if (string.IsNullOrEmpty(_apiHash))
+                throw new MissingApiConfigurationException("API_HASH");
+
+            _session = Session.TryLoadOrCreateNew(store, sessionUserId);
+            _transport = new TcpTransport(_session.ServerAddress, _session.Port,
+                httpProxyHost, httpProxyPort, proxyUserName, proxyPassword);
+
+        }
+
         public async Task<bool> ConnectAsync(bool reconnect = false)
         {
             if (_session.AuthKey == null || reconnect)


### PR DESCRIPTION
Example of use:

       TelegramClient client;

        bool useProxy = true;
        int apiId = 0;
        string apiHash = "";
        string apiPhone = "";
        string httpProxyHost = "";
        int httpProxyPort = 0;
        string proxyUsername = "";
        string proxyUserPwd = "";

        if (useProxy)
            client = new TelegramClient(apiId, apiHash, httpProxyHost, httpProxyPort, proxyUsername, proxyUserPwd);
        else
            client = new TelegramClient(apiId, apiHash);
        await client.ConnectAsync();