### PR TITLE
Add offset parameter to GetFile() method

### DIFF
--- a/TLSharp.Core/TelegramClient.cs
+++ b/TLSharp.Core/TelegramClient.cs
@@ -290,7 +290,7 @@ namespace TLSharp.Core
             });
         }
 
-        public async Task<TLFile> GetFile(TLAbsInputFileLocation location, int filePartSize)
+        public async Task<TLFile> GetFile(TLAbsInputFileLocation location, int filePartSize, int offset = 0)
         {
             TLFile result = null;
             try
@@ -298,7 +298,8 @@ namespace TLSharp.Core
                 result = await SendRequestAsync<TLFile>(new TLRequestGetFile()
                 {
                     location = location,
-                    limit = filePartSize
+                    limit = filePartSize,
+                    offset = offset
                 });
             }
             catch (FileMigrationException ex)


### PR DESCRIPTION
Hi,

I made this change as it is necessary for downloading larger file.

Indeed after a call to GetFile, TFile.bytes.Length could be lesser than filePartSize which obliges to call it back with an offset.

It has been tested in my code.

Thanks
