### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ List of donators:
 # Contributors
 * [Afshin Arani](http://aarani.ir) - TLGenerator, and a lot of other usefull things
 * [Knocte](https://github.com/knocte)
+* [RapidAPI](https://rapidapi.com/package/TelegramBot/functions?utm_source=TelegramGitHub&utm_medium=button)
 
 # License
 


### PR DESCRIPTION
I've added a link in your README to Telegram's functions page in RapidAPI. I've done this for a few Telegram SDKs to help those who are reading the READMEs, understand and test the API before use.