### PR TITLE
Fix issue with leaving session in a invalid state if GetFile throws an exception after reconnecting to another DC

### DIFF
--- a/TLSharp.Core/TelegramClient.cs
+++ b/TLSharp.Core/TelegramClient.cs
@@ -329,20 +329,24 @@ namespace TLSharp.Core
                 var serverPort = _session.Port;
 
                 await ReconnectToDcAsync(ex.DC);
-                var auth = await SendRequestAsync<TLAuthorization>(new TLRequestImportAuthorization
+                try
                 {
-                    bytes = exportedAuth.bytes,
-                    id = exportedAuth.id
-                });
-                result = await GetFile(location, filePartSize, offset);
-
-                _session.AuthKey = authKey;
-                _session.TimeOffset = timeOffset;
-                _transport = new TcpTransport(serverAddress, serverPort);
-                _session.ServerAddress = serverAddress;
-                _session.Port = serverPort;
-                await ConnectAsync();
-
+                    var auth = await SendRequestAsync<TLAuthorization>(new TLRequestImportAuthorization
+                    {
+                        bytes = exportedAuth.bytes,
+                        id = exportedAuth.id
+                    });
+                    result = await GetFile(location, filePartSize, offset);
+                }
+                finally
+                {
+                    _session.AuthKey = authKey;
+                    _session.TimeOffset = timeOffset;
+                    _transport = new TcpTransport(serverAddress, serverPort);
+                    _session.ServerAddress = serverAddress;
+                    _session.Port = serverPort;
+                    await ConnectAsync();
+                }
             }
 
             return result;


### PR DESCRIPTION
In TelegramClient.GetFile, if the file is in another DC, it reconnects to the DC to be able to get the file. In an exception is thrown after that whilst trying to download the file it doesn't reconnect to the original DC which leaves the session in an invalid state.

This wraps the calls after the ReconnectToDCAs in a try finally to ensure that whatever happens we always try to do the reconnect to the original DC.
