### PR TITLE
Make Session constructor public for custom ISessionStore imlementations

### DIFF
--- a/TLSharp.Core/Session.cs
+++ b/TLSharp.Core/Session.cs
@@ -73,7 +73,7 @@ namespace TLSharp.Core
 
         private ISessionStore _store;
 
-        private Session(ISessionStore store)
+        public Session(ISessionStore store)
         {
             random = new Random();
             _store = store;


### PR DESCRIPTION
**Load**() method in **ISessionStore** requires public constructor of **class Session** in some cases.
E.g., loading session from a db or a key-value store, manual loading from text-file, JSON/XML and so on.