### PR TITLE
Allow IP customisation (or any Session parameter)

### DIFF
--- a/TLSharp.Core/TelegramClient.cs
+++ b/TLSharp.Core/TelegramClient.cs
@@ -30,6 +30,8 @@ namespace TLSharp.Core
         private List<TLDcOption> dcOptions;
         private TcpClientConnectionHandler _handler;
 
+        public Session Session { get { return _session; } }
+
         public TelegramClient(int apiId, string apiHash,
             Session session = null, string sessionUserId = "session", TcpClientConnectionHandler handler = null)
         {

--- a/TLSharp.Core/TelegramClient.cs
+++ b/TLSharp.Core/TelegramClient.cs
@@ -31,22 +31,19 @@ namespace TLSharp.Core
         private TcpClientConnectionHandler _handler;
 
         public TelegramClient(int apiId, string apiHash,
-            ISessionStore store = null, string sessionUserId = "session", TcpClientConnectionHandler handler = null)
+            Session session = null, string sessionUserId = "session", TcpClientConnectionHandler handler = null)
         {
             if (apiId == default(int))
                 throw new MissingApiConfigurationException("API_ID");
             if (string.IsNullOrEmpty(apiHash))
                 throw new MissingApiConfigurationException("API_HASH");
 
-            if (store == null)
-                store = new FileSessionStore();
-
             TLContext.Init();
             _apiHash = apiHash;
             _apiId = apiId;
             _handler = handler;
 
-            _session = Session.TryLoadOrCreateNew(store, sessionUserId);
+            _session = Session.GetSession(session?.Store ?? new FileSessionStore(), session?.SessionUserId ?? sessionUserId, session);
             _transport = new TcpTransport(_session.ServerAddress, _session.Port, _handler);
         }
 


### PR DESCRIPTION
after checking out issue #441 because I had the same problem, this is my proposal to a permanent solution. 
Of course there is a good reason for a SessionStore to be in the constructor but, from my point of view, that is uncanny because the SessionStore object is just a wrapper around a File object and all the heavy lifting is done by the Session object (serialising and de-serialising). It made sense to me that the constructor should receive a Session object. To maintain compatibility and the original behaviour, TelegramClient will use the Session object as a hint to load the correct file. If no file has been loaded and none has been provided, only then a new Session with default settings will be created.

I've also added a property Session to TelegramClient, so the user can be retrieved in case it's already been authorized.