### PR TITLE
issue#768 fix exception 'Constructor Invalid Or Context.Init Not Called !'

### DIFF
--- a/TLSharp.Core/TelegramClient.cs
+++ b/TLSharp.Core/TelegramClient.cs
@@ -41,7 +41,6 @@ namespace TLSharp.Core
             if (store == null)
                 store = new FileSessionStore();
 
-            TLContext.Init();
             _apiHash = apiHash;
             _apiId = apiId;
             _handler = handler;

--- a/TeleSharp.TL/TLContext.cs
+++ b/TeleSharp.TL/TLContext.cs
@@ -12,7 +12,7 @@ namespace TeleSharp.TL
     {
         private static Dictionary<int, Type> Types;
 
-        public static void Init()
+        static TLContext()
         {
             Types = new Dictionary<int, Type>();
             Types = (from t in Assembly.GetExecutingAssembly().GetTypes()
@@ -22,6 +22,7 @@ namespace TeleSharp.TL
                      select t).ToDictionary(x => ((TLObjectAttribute)x.GetCustomAttribute(typeof(TLObjectAttribute))).Constructor, x => x);
             Types.Add(481674261, typeof(TLVector<>));
         }
+
         public static Type getType(int Constructor)
         {
             return Types[Constructor];


### PR DESCRIPTION
I used my implementation of FileSessionStore so that I could change the path to the session file.
When you load a session (before creating TelegramClient) from a file (if session is authorized), when the TLUser is deserialized, the 'Constructor Invalid Or Context.Init Not Called !' (inner NullReferenceException) error is thrown.

NullReferenceException here
![screenshot_70](https://user-images.githubusercontent.com/16295606/40689707-11ab6296-63ac-11e8-9869-7340a6428d4e.png)

It is necessary to initialize TLContext as in the commit and the problem will go away.
