### PR TITLE
Modified TcpClient setup to work with IPv6 addresses, fixing #773.

### DIFF
--- a/TLSharp.Core/Network/TcpTransport.cs
+++ b/TLSharp.Core/Network/TcpTransport.cs
@@ -16,10 +16,11 @@ namespace TLSharp.Core.Network
         {
             if (handler == null)
             {
-                _tcpClient = new TcpClient();
-
                 var ipAddress = IPAddress.Parse(address);
-                _tcpClient.Connect(ipAddress, port);
+                var endpoint = new IPEndPoint(ipAddress, port);
+
+                _tcpClient = new TcpClient(endpoint);
+                _tcpClient.Connect(endpoint);
             }
             else
                 _tcpClient = handler(address, port);


### PR DESCRIPTION
@knocte He's the new PR, with the whitespace gone. Sorry if this is getting confusing.

This is a continuation from #853. There, I attempted to avoid the crash by skipping IPv6 datacenters. In this branch, I actually fixed the crash by changing the way the TcpClient was setup, allowing IPv6 addresses.

