### PR TITLE
Added constructor option to toggle usage of IPv6 datacenter addresses.

### DIFF
--- a/TLSharp.Core/TelegramClient.cs
+++ b/TLSharp.Core/TelegramClient.cs
@@ -28,9 +28,11 @@ namespace TLSharp.Core
         private Session _session;
         private List<TLDcOption> dcOptions;
         private TcpClientConnectionHandler _handler;
+        private bool _useIpV6DataCenters;
 
         public TelegramClient(int apiId, string apiHash,
-            ISessionStore store = null, string sessionUserId = "session", TcpClientConnectionHandler handler = null)
+            ISessionStore store = null, string sessionUserId = "session", TcpClientConnectionHandler handler = null,
+            bool useIpV6DataCenters = true)
         {
             if (apiId == default(int))
                 throw new MissingApiConfigurationException("API_ID");
@@ -43,6 +45,7 @@ namespace TLSharp.Core
             _apiHash = apiHash;
             _apiId = apiId;
             _handler = handler;
+            _useIpV6DataCenters = useIpV6DataCenters;
 
             _session = Session.TryLoadOrCreateNew(store, sessionUserId);
             _transport = new TcpTransport(_session.DataCenter.Address, _session.DataCenter.Port, _handler);
@@ -89,7 +92,7 @@ namespace TLSharp.Core
                 exported = await SendRequestAsync<TLExportedAuthorization>(exportAuthorization);
             }
 
-            var dc = dcOptions.First(d => d.Id == dcId);
+            var dc = dcOptions.First(d => d.Id == dcId && (_useIpV6DataCenters || !d.Ipv6));
             var dataCenter = new DataCenter (dcId, dc.IpAddress, dc.Port);
 
             _transport = new TcpTransport(dc.IpAddress, dc.Port, _handler);
@@ -173,7 +176,7 @@ namespace TLSharp.Core
 
             if (String.IsNullOrWhiteSpace(code))
                 throw new ArgumentNullException(nameof(code));
-            
+
             var request = new TLRequestSignIn() { PhoneNumber = phoneNumber, PhoneCodeHash = phoneCodeHash, PhoneCode = code };
 
             await RequestWithDcMigration(request);
@@ -182,7 +185,7 @@ namespace TLSharp.Core
 
             return ((TLUser)request.Response.User);
         }
-        
+
         public async Task<TLPassword> GetPasswordSetting()
         {
             var request = new TLRequestGetPassword();
@@ -213,7 +216,7 @@ namespace TLSharp.Core
         public async Task<TLUser> SignUpAsync(string phoneNumber, string phoneCodeHash, string code, string firstName, string lastName)
         {
             var request = new TLRequestSignUp() { PhoneNumber = phoneNumber, PhoneCode = code, PhoneCodeHash = phoneCodeHash, FirstName = firstName, LastName = lastName };
-            
+
             await RequestWithDcMigration(request);
 
             OnUserAuthenticated(((TLUser)request.Response.User));
@@ -272,10 +275,10 @@ namespace TLSharp.Core
                 offsetPeer = new TLInputPeerSelf();
 
             var req = new TLRequestGetDialogs()
-            { 
-                OffsetDate = offsetDate, 
-                OffsetId = offsetId, 
-                OffsetPeer = offsetPeer, 
+            {
+                OffsetDate = offsetDate,
+                OffsetId = offsetId,
+                OffsetPeer = offsetPeer,
                 Limit = limit
             };
             return await SendRequestAsync<TLAbsDialogs>(req);


### PR DESCRIPTION
This should provide a workaround for #857 without disabling IPv6.

I wanted to clean up the code, and put the data-center selection method into a virtual function, so it could be overridden... But that didn't look as good, so I opted to just take the switch in as a constructor boolean.