### PR TITLE
Added .idea/ directory (for JetBrains Rider) to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,9 @@ _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user
 
+# JetBrains Rider holds their temp data in the ".idea/" directory
+.idea/
+
 # JustCode is a .NET coding add-in
 .JustCode
 


### PR DESCRIPTION
I use JetBrains Rider instead of Visual Studio. The .idea folder can be safely ignored, it's just metadata like what files you had open in the IDE.