### PR TITLE
Free TCP network stream

### DIFF
--- a/TLSharp.Core/Network/MtProtoPlainSender.cs
+++ b/TLSharp.Core/Network/MtProtoPlainSender.cs
@@ -37,7 +37,7 @@ namespace TLSharp.Core.Network
 
         public async Task<byte[]> Receive()
         {
-            var result = await _transport.Receieve();
+            var result = await _transport.Receive();
 
             using (var memoryStream = new MemoryStream(result.Body))
             {

--- a/TLSharp.Core/Network/MtProtoSender.cs
+++ b/TLSharp.Core/Network/MtProtoSender.cs
@@ -131,7 +131,7 @@ namespace TLSharp.Core.Network
         {
             while (!request.ConfirmReceived)
             {
-                var result = DecodeMessage((await _transport.Receieve()).Body);
+                var result = DecodeMessage((await _transport.Receive()).Body);
 
                 using (var messageStream = new MemoryStream(result.Item1, false))
                 using (var messageReader = new BinaryReader(messageStream))

--- a/TLSharp.Core/Network/TcpTransport.cs
+++ b/TLSharp.Core/Network/TcpTransport.cs
@@ -43,7 +43,7 @@ namespace TLSharp.Core.Network
             sendCounter++;
         }
 
-        public async Task<TcpMessage> Receieve()
+        public async Task<TcpMessage> Receive()
         {
             var packetLengthBytes = new byte[4];
             if (await _stream.ReadAsync(packetLengthBytes, 0, 4) != 4)


### PR DESCRIPTION
- Use single TCP network stream for read and write operations
- Cleanup TCP stream on disposing TcpTransport as Microsoft note :
https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.tcpclient.getstream?view=netframework-4.8