### PR TITLE
Add Session readonly field to TelegramClient

### DIFF
--- a/TLSharp.Core/TelegramClient.cs
+++ b/TLSharp.Core/TelegramClient.cs
@@ -29,6 +29,11 @@ namespace TLSharp.Core
         private List<TLDcOption> dcOptions;
         private TcpClientConnectionHandler _handler;
 
+        public Session Session
+        {
+            get { return _session; }
+        }
+
         public TelegramClient(int apiId, string apiHash,
             ISessionStore store = null, string sessionUserId = "session", TcpClientConnectionHandler handler = null)
         {


### PR DESCRIPTION
Add Session readonly field which let user read session properties like current logedin user's Username & etc.