### PR TITLE
Reformat exceptions

### DIFF
--- a/TLSharp.Core/Exceptions/CloudPasswordNeededException.cs
+++ b/TLSharp.Core/Exceptions/CloudPasswordNeededException.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace TLSharp.Core.Exceptions
+{
+    public class CloudPasswordNeededException : Exception
+    {
+        internal CloudPasswordNeededException(string msg) : base(msg) { }
+    }
+}

--- a/TLSharp.Core/Exceptions/InvalidPhoneCodeException.cs
+++ b/TLSharp.Core/Exceptions/InvalidPhoneCodeException.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace TLSharp.Core.Exceptions
+{
+    public class InvalidPhoneCodeException : Exception
+    {
+        internal InvalidPhoneCodeException(string msg) : base(msg) { }
+    }
+}

--- a/TLSharp.Core/Exceptions/MissingApiConfigurationException.cs
+++ b/TLSharp.Core/Exceptions/MissingApiConfigurationException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace TLSharp.Core.Exceptions
+{
+    public class MissingApiConfigurationException : Exception
+    {
+        public const string InfoUrl = "https://github.com/sochix/TLSharp#quick-configuration";
+
+        internal MissingApiConfigurationException(string invalidParamName) :
+            base($"Your {invalidParamName} setting is missing. Adjust the configuration first, see {InfoUrl}")
+        {
+        }
+    }
+}

--- a/TLSharp.Core/Network/Exceptions/DataCenterMigrationException.cs
+++ b/TLSharp.Core/Network/Exceptions/DataCenterMigrationException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace TLSharp.Core.Network.Exceptions
+{
+    internal abstract class DataCenterMigrationException : Exception
+    {
+        internal int DC { get; private set; }
+
+        private const string REPORT_MESSAGE =
+            " See: https://github.com/sochix/TLSharp#i-get-a-xxxmigrationexception-or-a-migrate_x-error";
+
+        protected DataCenterMigrationException(string msg, int dc) : base (msg + REPORT_MESSAGE)
+        {
+            DC = dc;
+        }
+    }
+}

--- a/TLSharp.Core/Network/Exceptions/FileMigrationException.cs
+++ b/TLSharp.Core/Network/Exceptions/FileMigrationException.cs
@@ -1,0 +1,10 @@
+﻿namespace TLSharp.Core.Network.Exceptions
+{
+    internal class FileMigrationException : DataCenterMigrationException
+    {
+        internal FileMigrationException(int dc)
+            : base ($"File located on a different DC: {dc}.", dc)
+        {
+        }
+    }
+}

--- a/TLSharp.Core/Network/Exceptions/FloodException.cs
+++ b/TLSharp.Core/Network/Exceptions/FloodException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace TLSharp.Core.Network.Exceptions
+{
+    public class FloodException : Exception
+    {
+        public TimeSpan TimeToWait { get; private set; }
+
+        internal FloodException(TimeSpan timeToWait)
+            : base($"Flood prevention. Telegram now requires your program to do requests again only after {timeToWait.TotalSeconds} seconds have passed ({nameof(TimeToWait)} property)." +
+                   " If you think the culprit of this problem may lie in TLSharp's implementation, open a Github issue please.")
+        {
+            TimeToWait = timeToWait;
+        }
+    }
+}

--- a/TLSharp.Core/Network/Exceptions/NetworkMigrationException.cs
+++ b/TLSharp.Core/Network/Exceptions/NetworkMigrationException.cs
@@ -1,0 +1,10 @@
+﻿namespace TLSharp.Core.Network.Exceptions
+{
+    internal class NetworkMigrationException : DataCenterMigrationException
+    {
+        internal NetworkMigrationException(int dc)
+            : base($"Network located on a different DC: {dc}.", dc)
+        {
+        }
+    }
+}

--- a/TLSharp.Core/Network/Exceptions/PhoneMigrationException.cs
+++ b/TLSharp.Core/Network/Exceptions/PhoneMigrationException.cs
@@ -1,0 +1,10 @@
+﻿namespace TLSharp.Core.Network.Exceptions
+{
+    internal class PhoneMigrationException : DataCenterMigrationException
+    {
+        internal PhoneMigrationException(int dc)
+            : base ($"Phone number registered to a different DC: {dc}.", dc)
+        {
+        }
+    }
+}

--- a/TLSharp.Core/Network/Exceptions/UserMigrationException.cs
+++ b/TLSharp.Core/Network/Exceptions/UserMigrationException.cs
@@ -1,0 +1,10 @@
+﻿namespace TLSharp.Core.Network.Exceptions
+{
+    internal class UserMigrationException : DataCenterMigrationException
+    {
+        internal UserMigrationException(int dc)
+            : base($"User located on a different DC: {dc}.", dc)
+        {
+        }
+    }
+}

--- a/TLSharp.Core/Network/MtProtoSender.cs
+++ b/TLSharp.Core/Network/MtProtoSender.cs
@@ -7,8 +7,10 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Ionic.Zlib;
+using TLSharp.Core.Exceptions;
 using TLSharp.Core.MTProto;
 using TLSharp.Core.MTProto.Crypto;
+using TLSharp.Core.Network.Exceptions;
 using TLSharp.Core.Requests;
 using TLSharp.Core.Utils;
 
@@ -521,63 +523,6 @@ namespace TLSharp.Core.Network
         private MemoryStream makeMemory(int len)
         {
             return new MemoryStream(new byte[len], 0, len, true, true);
-        }
-    }
-
-    public class FloodException : Exception
-    {
-        public TimeSpan TimeToWait { get; private set; }
-
-        internal FloodException(TimeSpan timeToWait)
-            : base($"Flood prevention. Telegram now requires your program to do requests again only after {timeToWait.TotalSeconds} seconds have passed ({nameof(TimeToWait)} property)." +
-                    " If you think the culprit of this problem may lie in TLSharp's implementation, open a Github issue please.")
-        {
-            TimeToWait = timeToWait;
-        }
-    }
-
-    internal abstract class DataCenterMigrationException : Exception
-    {
-        internal int DC { get; private set; }
-
-        private const string REPORT_MESSAGE =
-            " See: https://github.com/sochix/TLSharp#i-get-a-xxxmigrationexception-or-a-migrate_x-error";
-
-        protected DataCenterMigrationException(string msg, int dc) : base (msg + REPORT_MESSAGE)
-        {
-            DC = dc;
-        }
-    }
-
-    internal class PhoneMigrationException : DataCenterMigrationException
-    {
-        internal PhoneMigrationException(int dc)
-            : base ($"Phone number registered to a different DC: {dc}.", dc)
-        {
-        }
-    }
-
-    internal class FileMigrationException : DataCenterMigrationException
-    {
-        internal FileMigrationException(int dc)
-            : base ($"File located on a different DC: {dc}.", dc)
-        {
-        }
-    }
-
-    internal class UserMigrationException : DataCenterMigrationException
-    {
-        internal UserMigrationException(int dc)
-            : base($"User located on a different DC: {dc}.", dc)
-        {
-        }
-    }
-    
-    internal class NetworkMigrationException : DataCenterMigrationException
-    {
-        internal NetworkMigrationException(int dc)
-            : base($"Network located on a different DC: {dc}.", dc)
-        {
         }
     }
 }

--- a/TLSharp.Core/TLSharp.Core.csproj
+++ b/TLSharp.Core/TLSharp.Core.csproj
@@ -48,6 +48,9 @@
     <Compile Include="Auth\Step1_PQRequest.cs" />
     <Compile Include="Auth\Step2_DHExchange.cs" />
     <Compile Include="Auth\Step3_CompleteDHExchange.cs" />
+    <Compile Include="Exceptions\CloudPasswordNeededException.cs" />
+    <Compile Include="Exceptions\InvalidPhoneCodeException.cs" />
+    <Compile Include="Exceptions\MissingApiConfigurationException.cs" />
     <Compile Include="MTProto\Crypto\AES.cs" />
     <Compile Include="MTProto\Crypto\AuthKey.cs" />
     <Compile Include="MTProto\Crypto\BigInteger.cs" />
@@ -57,10 +60,16 @@
     <Compile Include="MTProto\Crypto\RSA.cs" />
     <Compile Include="MTProto\Crypto\Salt.cs" />
     <Compile Include="MTProto\Serializers.cs" />
+    <Compile Include="Network\Exceptions\DataCenterMigrationException.cs" />
+    <Compile Include="Network\Exceptions\FileMigrationException.cs" />
+    <Compile Include="Network\Exceptions\FloodException.cs" />
     <Compile Include="Network\MtProtoPlainSender.cs" />
     <Compile Include="Network\MtProtoSender.cs" />
+    <Compile Include="Network\Exceptions\NetworkMigrationException.cs" />
+    <Compile Include="Network\Exceptions\PhoneMigrationException.cs" />
     <Compile Include="Network\TcpMessage.cs" />
     <Compile Include="Network\TcpTransport.cs" />
+    <Compile Include="Network\Exceptions\UserMigrationException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Requests\AckRequest.cs" />
     <Compile Include="Requests\PingRequest.cs" />

--- a/TLSharp.Core/TelegramClient.cs
+++ b/TLSharp.Core/TelegramClient.cs
@@ -12,8 +12,10 @@ using TeleSharp.TL.Help;
 using TeleSharp.TL.Messages;
 using TeleSharp.TL.Upload;
 using TLSharp.Core.Auth;
+using TLSharp.Core.Exceptions;
 using TLSharp.Core.MTProto.Crypto;
 using TLSharp.Core.Network;
+using TLSharp.Core.Network.Exceptions;
 using TLSharp.Core.Utils;
 using TLAuthorization = TeleSharp.TL.Auth.TLAuthorization;
 
@@ -445,24 +447,5 @@ namespace TLSharp.Core
                 _transport = null;
             }
         }
-    }
-
-    public class MissingApiConfigurationException : Exception
-    {
-        public const string InfoUrl = "https://github.com/sochix/TLSharp#quick-configuration";
-
-        internal MissingApiConfigurationException(string invalidParamName) :
-            base($"Your {invalidParamName} setting is missing. Adjust the configuration first, see {InfoUrl}")
-        {
-        }
-    }
-
-    public class InvalidPhoneCodeException : Exception
-    {
-        internal InvalidPhoneCodeException(string msg) : base(msg) { }
-    }
-    public class CloudPasswordNeededException : Exception
-    {
-        internal CloudPasswordNeededException(string msg) : base(msg) { }
     }
 }

--- a/TLSharp.Tests/TLSharpTests.cs
+++ b/TLSharp.Tests/TLSharpTests.cs
@@ -10,7 +10,9 @@ using System.Threading.Tasks;
 using TeleSharp.TL;
 using TeleSharp.TL.Messages;
 using TLSharp.Core;
+using TLSharp.Core.Exceptions;
 using TLSharp.Core.Network;
+using TLSharp.Core.Network.Exceptions;
 using TLSharp.Core.Requests;
 using TLSharp.Core.Utils;
 


### PR DESCRIPTION
Exceptions moved to separate folders:
- Exceptions from MtProtoSender.cs to TLSharp.Core/Network/Exceptions
- Exceptions from TelegramClient.cs to TLSharp.Core/Exceptions