### PR TITLE
Improvements for async methods

### DIFF
--- a/TLSharp.Core/Auth/Authenticator.cs
+++ b/TLSharp.Core/Auth/Authenticator.cs
@@ -1,35 +1,43 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using TLSharp.Core.Network;
 
 namespace TLSharp.Core.Auth
 {
     public static class Authenticator
     {
-        public static async Task<Step3_Response> DoAuthentication(TcpTransport transport)
+        public static async Task<Step3_Response> DoAuthentication(TcpTransport transport, CancellationToken token = default(CancellationToken))
         {
+            token.ThrowIfCancellationRequested();
+
             var sender = new MtProtoPlainSender(transport);
             var step1 = new Step1_PQRequest();
 
-            await sender.Send(step1.ToBytes());
-            var step1Response = step1.FromBytes(await sender.Receive());
+            await sender.Send(step1.ToBytes(), token).ConfigureAwait(false);
+            var step1Response = step1.FromBytes(await sender.Receive(token)
+                .ConfigureAwait(false));
 
             var step2 = new Step2_DHExchange();
             await sender.Send(step2.ToBytes(
-                step1Response.Nonce,
-                step1Response.ServerNonce,
-                step1Response.Fingerprints,
-                step1Response.Pq));
+                    step1Response.Nonce,
+                    step1Response.ServerNonce,
+                    step1Response.Fingerprints,
+                    step1Response.Pq), token)
+                .ConfigureAwait(false);
 
-            var step2Response = step2.FromBytes(await sender.Receive());
+            var step2Response = step2.FromBytes(await sender.Receive(token)
+                .ConfigureAwait(false));
 
             var step3 = new Step3_CompleteDHExchange();
             await sender.Send(step3.ToBytes(
-                step2Response.Nonce,
-                step2Response.ServerNonce,
-                step2Response.NewNonce,
-                step2Response.EncryptedAnswer));
+                    step2Response.Nonce,
+                    step2Response.ServerNonce,
+                    step2Response.NewNonce,
+                    step2Response.EncryptedAnswer), token)
+                .ConfigureAwait(false);
 
-            var step3Response = step3.FromBytes(await sender.Receive());
+            var step3Response = step3.FromBytes(await sender.Receive(token)
+                .ConfigureAwait(false));
 
             return step3Response;
         }

--- a/TLSharp.Core/Network/MtProtoPlainSender.cs
+++ b/TLSharp.Core/Network/MtProtoPlainSender.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace TLSharp.Core.Network
@@ -17,8 +18,10 @@ namespace TLSharp.Core.Network
             random = new Random();
         }
 
-        public async Task Send(byte[] data)
+        public async Task Send(byte[] data, CancellationToken token = default(CancellationToken))
         {
+            token.ThrowIfCancellationRequested();
+
             using (var memoryStream = new MemoryStream())
             {
                 using (var binaryWriter = new BinaryWriter(memoryStream))
@@ -30,14 +33,16 @@ namespace TLSharp.Core.Network
 
                     byte[] packet = memoryStream.ToArray();
 
-                    await _transport.Send(packet);
+                    await _transport.Send(packet, token).ConfigureAwait(false);
                 }
             }
         }
 
-        public async Task<byte[]> Receive()
+        public async Task<byte[]> Receive(CancellationToken token = default(CancellationToken))
         {
-            var result = await _transport.Receive();
+            token.ThrowIfCancellationRequested();
+
+            var result = await _transport.Receive(token).ConfigureAwait(false);
 
             using (var memoryStream = new MemoryStream(result.Body))
             {

--- a/TLSharp.Core/Network/MtProtoSender.cs
+++ b/TLSharp.Core/Network/MtProtoSender.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Ionic.Zlib;
+using TeleSharp.TL;
 using TLSharp.Core.Exceptions;
 using TLSharp.Core.MTProto;
 using TLSharp.Core.MTProto.Crypto;
@@ -36,8 +37,10 @@ namespace TLSharp.Core.Network
             return confirmed ? _session.Sequence++ * 2 + 1 : _session.Sequence * 2;
         }
 
-        public async Task Send(TeleSharp.TL.TLMethod request)
+        public async Task Send(TeleSharp.TL.TLMethod request, CancellationToken token = default(CancellationToken))
         {
+            token.ThrowIfCancellationRequested();
+
             // TODO: refactor
             if (needConfirmation.Any())
             {
@@ -46,7 +49,7 @@ namespace TLSharp.Core.Network
                 using (var writer = new BinaryWriter(memory))
                 {
                     ackRequest.SerializeBody(writer);
-                    await Send(memory.ToArray(), ackRequest);
+                    await Send(memory.ToArray(), ackRequest, token).ConfigureAwait(false);
                     needConfirmation.Clear();
                 }
             }
@@ -56,14 +59,16 @@ namespace TLSharp.Core.Network
             using (var writer = new BinaryWriter(memory))
             {
                 request.SerializeBody(writer);
-                await Send(memory.ToArray(), request);
+                await Send(memory.ToArray(), request, token).ConfigureAwait(false);
             }
 
             _session.Save();
         }
 
-        public async Task Send(byte[] packet, TeleSharp.TL.TLMethod request)
+        public async Task Send(byte[] packet, TeleSharp.TL.TLMethod request, CancellationToken token = default(CancellationToken))
         {
+            token.ThrowIfCancellationRequested();
+
             request.MessageId = _session.GetNewMessageId();
 
             byte[] msgKey;
@@ -92,7 +97,7 @@ namespace TLSharp.Core.Network
                     writer.Write(msgKey);
                     writer.Write(ciphertext);
 
-                    await _transport.Send(ciphertextPacket.GetBuffer());
+                    await _transport.Send(ciphertextPacket.GetBuffer(), token).ConfigureAwait(false);
                 }
             }
         }
@@ -129,37 +134,43 @@ namespace TLSharp.Core.Network
             return new Tuple<byte[], ulong, int>(message, remoteMessageId, remoteSequence);
         }
 
-        public async Task<byte[]> Receive(TeleSharp.TL.TLMethod request)
+        public async Task<byte[]> Receive(TeleSharp.TL.TLMethod request, CancellationToken token = default(CancellationToken))
         {
             while (!request.ConfirmReceived)
             {
-                var result = DecodeMessage((await _transport.Receive()).Body);
+                var result = DecodeMessage((await _transport.Receive(token).ConfigureAwait(false)).Body);
 
                 using (var messageStream = new MemoryStream(result.Item1, false))
                 using (var messageReader = new BinaryReader(messageStream))
                 {
-                    processMessage(result.Item2, result.Item3, messageReader, request);
+                    processMessage(result.Item2, result.Item3, messageReader, request, token);
                 }
+
+                token.ThrowIfCancellationRequested();
             }
 
             return null;
         }
 
-        public async Task SendPingAsync()
+        public async Task SendPingAsync(CancellationToken token = default(CancellationToken))
         {
+            token.ThrowIfCancellationRequested();
+
             var pingRequest = new PingRequest();
             using (var memory = new MemoryStream())
             using (var writer = new BinaryWriter(memory))
             {
                 pingRequest.SerializeBody(writer);
-                await Send(memory.ToArray(), pingRequest);
+                await Send(memory.ToArray(), pingRequest, token).ConfigureAwait(false);
             }
 
-            await Receive(pingRequest);
+            await Receive(pingRequest, token).ConfigureAwait(false);
         }
 
-        private bool processMessage(ulong messageId, int sequence, BinaryReader messageReader, TeleSharp.TL.TLMethod request)
+        private bool processMessage(ulong messageId, int sequence, BinaryReader messageReader, TLMethod request, CancellationToken token = default(CancellationToken))
         {
+            token.ThrowIfCancellationRequested();
+
             // TODO: check salt
             // TODO: check sessionid
             // TODO: check seqno
@@ -173,7 +184,7 @@ namespace TLSharp.Core.Network
             {
                 case 0x73f1f8dc: // container
                                  //logger.debug("MSG container");
-                    return HandleContainer(messageId, sequence, messageReader, request);
+                    return HandleContainer(messageId, sequence, messageReader, request, token);
                 case 0x7abe77ec: // ping
                                  //logger.debug("MSG ping");
                     return HandlePing(messageId, sequence, messageReader);
@@ -191,7 +202,7 @@ namespace TLSharp.Core.Network
                     return HandleMsgsAck(messageId, sequence, messageReader);
                 case 0xedab447b: // bad_server_salt
                                  //logger.debug("MSG bad_server_salt");
-                    return HandleBadServerSalt(messageId, sequence, messageReader, request);
+                    return HandleBadServerSalt(messageId, sequence, messageReader, request, token);
                 case 0xa7eff811: // bad_msg_notification
                                  //logger.debug("MSG bad_msg_notification");
                     return HandleBadMsgNotification(messageId, sequence, messageReader);
@@ -203,7 +214,7 @@ namespace TLSharp.Core.Network
                     return HandleRpcResult(messageId, sequence, messageReader, request);
                 case 0x3072cfa1: // gzip_packed
                                  //logger.debug("MSG gzip_packed");
-                    return HandleGzipPacked(messageId, sequence, messageReader, request);
+                    return HandleGzipPacked(messageId, sequence, messageReader, request, token);
                 case 0xe317af7e:
                 case 0xd3f45784:
                 case 0x2b2fbd4e:
@@ -235,14 +246,16 @@ namespace TLSharp.Core.Network
 			*/
         }
 
-        private bool HandleGzipPacked(ulong messageId, int sequence, BinaryReader messageReader, TeleSharp.TL.TLMethod request)
+        private bool HandleGzipPacked(ulong messageId, int sequence, BinaryReader messageReader, TLMethod request, CancellationToken token = default(CancellationToken))
         {
+            token.ThrowIfCancellationRequested();
+
             uint code = messageReader.ReadUInt32();
             byte[] packedData = GZipStream.UncompressBuffer(Serializers.Bytes.Read(messageReader));
             using (MemoryStream packedStream = new MemoryStream(packedData, false))
             using (BinaryReader compressedReader = new BinaryReader(packedStream))
             {
-                processMessage(messageId, sequence, compressedReader, request);
+                processMessage(messageId, sequence, compressedReader, request, token);
             }
 
             return true;
@@ -414,8 +427,10 @@ namespace TLSharp.Core.Network
             return true;
         }
 
-        private bool HandleBadServerSalt(ulong messageId, int sequence, BinaryReader messageReader, TeleSharp.TL.TLMethod request)
+        private bool HandleBadServerSalt(ulong messageId, int sequence, BinaryReader messageReader, TLMethod request, CancellationToken token = default(CancellationToken))
         {
+            token.ThrowIfCancellationRequested();
+
             uint code = messageReader.ReadUInt32();
             ulong badMsgId = messageReader.ReadUInt64();
             int badMsgSeqNo = messageReader.ReadInt32();
@@ -427,7 +442,7 @@ namespace TLSharp.Core.Network
             _session.Salt = newSalt;
 
             //resend
-            Send(request);
+            Send(request, token);
             /*
             if(!runningRequests.ContainsKey(badMsgId)) {
                 logger.debug("bad server salt on unknown message");
@@ -493,8 +508,10 @@ namespace TLSharp.Core.Network
             return false;
         }
 
-        private bool HandleContainer(ulong messageId, int sequence, BinaryReader messageReader, TeleSharp.TL.TLMethod request)
+        private bool HandleContainer(ulong messageId, int sequence, BinaryReader messageReader, TLMethod request, CancellationToken token = default(CancellationToken))
         {
+            token.ThrowIfCancellationRequested();
+
             uint code = messageReader.ReadUInt32();
             int size = messageReader.ReadInt32();
             for (int i = 0; i < size; i++)
@@ -505,7 +522,7 @@ namespace TLSharp.Core.Network
                 long beginPosition = messageReader.BaseStream.Position;
                 try
                 {
-                    if (!processMessage(innerMessageId, sequence, messageReader, request))
+                    if (!processMessage(innerMessageId, sequence, messageReader, request, token))
                     {
                         messageReader.BaseStream.Position = beginPosition + innerLength;
                     }

--- a/TLSharp.Core/Network/TcpTransport.cs
+++ b/TLSharp.Core/Network/TcpTransport.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace TLSharp.Core.Network
@@ -32,26 +33,26 @@ namespace TLSharp.Core.Network
             }
         }
 
-        public async Task Send(byte[] packet)
+        public async Task Send(byte[] packet, CancellationToken token = default(CancellationToken))
         {
             if (!_tcpClient.Connected)
                 throw new InvalidOperationException("Client not connected to server.");
 
             var tcpMessage = new TcpMessage(sendCounter, packet);
 
-            await _stream.WriteAsync(tcpMessage.Encode(), 0, tcpMessage.Encode().Length);
+            await _stream.WriteAsync(tcpMessage.Encode(), 0, tcpMessage.Encode().Length, token).ConfigureAwait(false);
             sendCounter++;
         }
 
-        public async Task<TcpMessage> Receive()
+        public async Task<TcpMessage> Receive(CancellationToken token = default(CancellationToken))
         {
             var packetLengthBytes = new byte[4];
-            if (await _stream.ReadAsync(packetLengthBytes, 0, 4) != 4)
+            if (await _stream.ReadAsync(packetLengthBytes, 0, 4, token).ConfigureAwait(false) != 4)
                 throw new InvalidOperationException("Couldn't read the packet length");
             int packetLength = BitConverter.ToInt32(packetLengthBytes, 0);
 
             var seqBytes = new byte[4];
-            if (await _stream.ReadAsync(seqBytes, 0, 4) != 4)
+            if (await _stream.ReadAsync(seqBytes, 0, 4, token).ConfigureAwait(false) != 4)
                 throw new InvalidOperationException("Couldn't read the sequence");
             int seq = BitConverter.ToInt32(seqBytes, 0);
 
@@ -62,7 +63,7 @@ namespace TLSharp.Core.Network
             do
             {
                 var bodyByte = new byte[packetLength - 12];
-                var availableBytes = await _stream.ReadAsync(bodyByte, 0, neededToRead);
+                var availableBytes = await _stream.ReadAsync(bodyByte, 0, neededToRead, token).ConfigureAwait(false);
                 neededToRead -= availableBytes;
                 Buffer.BlockCopy(bodyByte, 0, body, readBytes, availableBytes);
                 readBytes += availableBytes;
@@ -70,7 +71,7 @@ namespace TLSharp.Core.Network
             while (readBytes != packetLength - 12);
 
             var crcBytes = new byte[4];
-            if (await _stream.ReadAsync(crcBytes, 0, 4) != 4)
+            if (await _stream.ReadAsync(crcBytes, 0, 4, token).ConfigureAwait(false) != 4)
                 throw new InvalidOperationException("Couldn't read the crc");
             int checksum = BitConverter.ToInt32(crcBytes, 0);
 


### PR DESCRIPTION
Because there is no more actions from author in PR  #883 i decide to create this PR by myself.

@knocte, i tried to do all fixes which you requested from the author.
All async methods now contains CancellationToken with default value (CancellationToken.None)
And one more fix - i detect that SendAuthenticatetRequestAsync wasn't used in some methods, that need auth.
Therefore i changed it and changed private modifier in SendAuthenticatedRequestAsync to internal. It's needed for methods that exists in UploadHelper.cs.

I'm waiting for your review.