### PR TITLE
Fix problem with TLRequestGetStickerSet

### DIFF
--- a/TeleSharp.TL/TL/Messages/TLStickerSet.cs
+++ b/TeleSharp.TL/TL/Messages/TLStickerSet.cs
@@ -18,7 +18,7 @@ namespace TeleSharp.TL.Messages
             }
         }
 
-        public TLStickerSet Set { get; set; }
+        public TL.TLStickerSet Set { get; set; }
         public TLVector<TLStickerPack> Packs { get; set; }
         public TLVector<TLAbsDocument> Documents { get; set; }
 
@@ -30,7 +30,7 @@ namespace TeleSharp.TL.Messages
 
         public override void DeserializeBody(BinaryReader br)
         {
-            Set = (TLStickerSet)ObjectUtils.DeserializeObject(br);
+            Set = (TL.TLStickerSet)ObjectUtils.DeserializeObject(br);
             Packs = (TLVector<TLStickerPack>)ObjectUtils.DeserializeVector<TLStickerPack>(br);
             Documents = (TLVector<TLAbsDocument>)ObjectUtils.DeserializeVector<TLAbsDocument>(br);
 


### PR DESCRIPTION
When trying to SendRequest with TLRequestGetStickerSet throws an exception saying "cannot cast object of type TeleSharp.TL.TLStickerSet to TeleSharp.TL.Messages.TLStickerSet".