### PR TITLE
updated link to the latest schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ Don't panic. You can call any method with help of `SendRequestAsync` function. F
 
 **Where you can find a list of requests and its params?**
 
-The only way is [Telegram API docs](https://core.telegram.org/methods). Yes, it's outdated. But there is no other source.
-Latest scheme in JSON format you can find [here](https://gist.github.com/aarani/b22b7cda024973dff68e1672794b0298)
+Official API documentation at [Telegram API docs](https://core.telegram.org/methods).
+You can find official schema in JSON [here](https://core.telegram.org/schema/json).
 
 ## What things can I Implement (Project Roadmap)?
 


### PR DESCRIPTION
docs available at core.telegram.org are now pretty much up to date. (Layer 105)
also the latest scheme can be found in official tdesktop repo.