### PR TITLE
addresses connection issues

### DIFF
--- a/TLSharp.Core/TelegramClient.cs
+++ b/TLSharp.Core/TelegramClient.cs
@@ -72,6 +72,11 @@ namespace TLSharp.Core
         {
             token.ThrowIfCancellationRequested();
 
+            if (!transport.IsConnected)
+                await transport.Connect();
+            if (!transport.IsConnected)
+                throw new Exception("Connection to Telegram failed");
+
             if (session.AuthKey == null || reconnect)
             {
                 var result = await Authenticator.DoAuthentication(transport, token).ConfigureAwait(false);


### PR DESCRIPTION
! IsConnected is restored as it was before
+ TcpTransport has got a new Connect method which properly initializes the underlying tcpclient, this makes it possible to reconnect in case the tcpClient gets disconnected, without restarting the application or recreating a new TelegramClient object.