### PR TITLE
Created a .NET Core project files

### DIFF
--- a/TLSharp.Core/Properties/AssemblyInfo.cs
+++ b/TLSharp.Core/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("TLSharp.Core")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("TLSharp.Core")]
+//[assembly: AssemblyTitle("TLSharp.Core")]
+//[assembly: AssemblyDescription("")]
+//[assembly: AssemblyConfiguration("")]
+//[assembly: AssemblyCompany("")]
+//[assembly: AssemblyProduct("TLSharp.Core")]
 [assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+//[assembly: AssemblyVersion("1.0.0.0")]
+//[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TLSharp.Core/TLSharp.CoreCore.csproj
+++ b/TLSharp.Core/TLSharp.CoreCore.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Authors>Mahdi K. Fard</Authors>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Description>A port of TLSharp for .NET Standard 2.0.</Description>
+    <AssemblyVersion>1.0.0</AssemblyVersion>
+    <FileVersion>1.0.0</FileVersion>
+    <Version>1.0.0</Version>
+    <RepositoryUrl>https://github.com/xclud/Telegram</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/xclud/Telegram</PackageProjectUrl>
+    <PackageTags>Telegram</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TLSchema" Version="1.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Requests\AuthSendCodeRequest.cs" />
+    <Compile Remove="Requests\AuthSignInRequest.cs" />
+    <Compile Remove="Requests\DownloadFileRequest.cs" />
+    <Compile Remove="Requests\InitConnectionRequest.cs" />
+    <Compile Remove="Requests\MTProtoRequest.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TeleSharp.TL\TeleSharp.TLCore.csproj" />
+  </ItemGroup>
+</Project>

--- a/TeleSharp.TL/Properties/AssemblyInfo.cs
+++ b/TeleSharp.TL/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("TeleSharp.TL")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("TeleSharp.TL")]
+//[assembly: AssemblyTitle("TeleSharp.TL")]
+//[assembly: AssemblyDescription("")]
+//[assembly: AssemblyConfiguration("")]
+//[assembly: AssemblyCompany("")]
+//[assembly: AssemblyProduct("TeleSharp.TL")]
 [assembly: AssemblyCopyright("Copyright ©  2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+//[assembly: AssemblyVersion("1.0.0.0")]
+//[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TeleSharp.TL/TLContext.cs
+++ b/TeleSharp.TL/TLContext.cs
@@ -20,7 +20,10 @@ namespace TeleSharp.TL
                      where t.IsSubclassOf(typeof(TLObject))
                      where t.GetCustomAttribute(typeof(TLObjectAttribute)) != null
                      select t).ToDictionary(x => ((TLObjectAttribute)x.GetCustomAttribute(typeof(TLObjectAttribute))).Constructor, x => x);
-            Types.Add(481674261, typeof(TLVector<>));
+            if (!Types.TryGetValue(481674261, out _))
+            {
+                Types.Add(481674261, typeof(TLVector<>));
+            }
         }
 
         public static Type getType(int Constructor)

--- a/TeleSharp.TL/TeleSharp.TLCore.csproj
+++ b/TeleSharp.TL/TeleSharp.TLCore.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Authors>Mahdi K. Fard</Authors>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Description>A port of TLSharp for .NET Standard 2.0.</Description>
+    <AssemblyVersion>1.0.0</AssemblyVersion>
+    <FileVersion>1.0.0</FileVersion>
+    <Version>1.0.0</Version>
+    <RepositoryUrl>https://github.com/xclud/Telegram</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/xclud/Telegram</PackageProjectUrl>
+    <PackageTags>Telegram</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TLSchema" Version="1.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Requests\AuthSendCodeRequest.cs" />
+    <Compile Remove="Requests\AuthSignInRequest.cs" />
+    <Compile Remove="Requests\DownloadFileRequest.cs" />
+    <Compile Remove="Requests\InitConnectionRequest.cs" />
+    <Compile Remove="Requests\MTProtoRequest.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
There are 2 ways to solve the issue here:
1. Comment out the duplicate values.
2. Exclude the assembly info from the project

I chose 1 just because I wanted to preserve the rest of the attributes.