### PR TITLE
Client: add call for resendCode request

### DIFF
--- a/TLSharp.Core/TelegramClient.cs
+++ b/TLSharp.Core/TelegramClient.cs
@@ -207,6 +207,21 @@ namespace TLSharp.Core
             return request.Response.PhoneCodeHash;
         }
 
+        public async Task<string> ResendCodeRequestAsync(string phoneNumber, string phoneCodeHash, CancellationToken token = default(CancellationToken))
+        {
+            if (String.IsNullOrWhiteSpace(phoneNumber))
+                throw new ArgumentNullException(nameof(phoneNumber));
+
+            if(String.IsNullOrWhiteSpace(phoneCodeHash))
+                throw new ArgumentNullException(nameof(phoneCodeHash));
+
+            var request = new TLRequestResendCode() { PhoneNumber = phoneNumber, PhoneCodeHash = phoneCodeHash };
+
+            await RequestWithDcMigration(request, token).ConfigureAwait(false);
+
+            return request.Response.PhoneCodeHash;
+        }
+        
         public async Task<TLUser> MakeAuthAsync(string phoneNumber, string phoneCodeHash, string code, CancellationToken token = default(CancellationToken))
         {
             if (String.IsNullOrWhiteSpace(phoneNumber))

--- a/TLSharp.Tests.NUnit/Test.cs
+++ b/TLSharp.Tests.NUnit/Test.cs
@@ -22,6 +22,12 @@ namespace TLSharp.Tests
         }
 
         [Test]
+        public async override Task AuthUserByResendCode()
+        {
+            await base.AuthUserByResendCode();
+        }
+
+        [Test]
         public override async Task SendMessageTest()
         {
             await base.SendMessageTest();

--- a/TLSharp.Tests.VS/TLSharpTestsVs.cs
+++ b/TLSharp.Tests.VS/TLSharpTestsVs.cs
@@ -21,6 +21,12 @@ namespace TLSharp.Tests
         }
 
         [TestMethod]
+        public override async Task AuthUserByResendCode()
+        {
+            await base.AuthUserByResendCode();
+        }
+        
+        [TestMethod]
         public override async Task SendMessageTest()
         {
             await base.SendMessageTest();


### PR DESCRIPTION
TelegramClient: added a call to resend code request.
The call needs two parameters: 

- phoneNumber - number used within sendCode() request
- phoneCodeHash - hash received as a result from sendCode() request
Note: Telegram switches the type of code it sends during resend. If sendCode request got a Telegram message with the code, resendCode request will get SMS message with the code.
more details: https://core.telegram.org/method/auth.resendCode